### PR TITLE
Functional changes to Nimbus for Manta v3.3.0

### DIFF
--- a/nimbus-consensus/src/import_queue.rs
+++ b/nimbus-consensus/src/import_queue.rs
@@ -273,3 +273,28 @@ where
 		self.inner.import_block(block_import_params, cache).await
 	}
 }
+
+/// Parameters of [`build_verifier`].
+pub struct BuildVerifierParams<Client, Block, CIDP> {
+	/// The client to interact with the chain.
+	pub client: Arc<Client>,
+	/// Something that can create the inherent data providers.
+	pub create_inherent_data_providers: CIDP,
+	/// ????
+	pub _marker: PhantomData<Block>,
+}
+
+/// Build a [`NimbusVerifier`] ( allows for composing nimbus with other consensus engines )
+pub fn build_verifier<Client, Block, CIDP>(
+	BuildVerifierParams {
+		client,
+		create_inherent_data_providers,
+		_marker,
+	}: BuildVerifierParams<Client, Block, CIDP>,
+) ->  Verifier<Client, Block, CIDP> {
+	Verifier{
+		client,
+		create_inherent_data_providers,
+		_marker,
+	}
+}

--- a/nimbus-consensus/src/import_queue.rs
+++ b/nimbus-consensus/src/import_queue.rs
@@ -45,6 +45,20 @@ pub struct Verifier<Client, Block, CIDP> {
 	_marker: PhantomData<Block>,
 }
 
+impl<Client, Block, CIDP> Verifier<Client, Block, CIDP> 
+{
+/// Build a [`NimbusVerifier`] ( allows for composing nimbus with other consensus engines )
+pub fn new(
+	client: Arc<Client>,
+	create_inherent_data_providers: CIDP,
+) ->  Self {
+	Self{
+		client,
+		create_inherent_data_providers,
+		_marker : PhantomData{},
+	}
+}
+}
 #[async_trait::async_trait]
 impl<Client, Block, CIDP> VerifierT<Block> for Verifier<Client, Block, CIDP>
 where
@@ -201,11 +215,10 @@ where
 	<Client as ProvideRuntimeApi<Block>>::Api: BlockBuilderApi<Block>,
 	CIDP: CreateInherentDataProviders<Block, ()> + 'static,
 {
-	let verifier = Verifier {
+	let verifier = Verifier::new(
 		client,
 		create_inherent_data_providers,
-		_marker: PhantomData,
-	};
+);
 
 	Ok(BasicQueue::new(
 		verifier,
@@ -271,30 +284,5 @@ where
 
 		// Now continue on to the rest of the import pipeline.
 		self.inner.import_block(block_import_params, cache).await
-	}
-}
-
-/// Parameters of [`build_verifier`].
-pub struct BuildVerifierParams<Client, Block, CIDP> {
-	/// The client to interact with the chain.
-	pub client: Arc<Client>,
-	/// Something that can create the inherent data providers.
-	pub create_inherent_data_providers: CIDP,
-	/// ????
-	pub _marker: PhantomData<Block>,
-}
-
-/// Build a [`NimbusVerifier`] ( allows for composing nimbus with other consensus engines )
-pub fn build_verifier<Client, Block, CIDP>(
-	BuildVerifierParams {
-		client,
-		create_inherent_data_providers,
-		_marker,
-	}: BuildVerifierParams<Client, Block, CIDP>,
-) ->  Verifier<Client, Block, CIDP> {
-	Verifier{
-		client,
-		create_inherent_data_providers,
-		_marker,
 	}
 }

--- a/nimbus-consensus/src/import_queue.rs
+++ b/nimbus-consensus/src/import_queue.rs
@@ -36,7 +36,7 @@ use sp_runtime::{
 
 /// The Nimbus verifier strips the seal digest, and checks that it is a valid signature by
 /// the same key that was injected into the runtime and noted in the Seal digest.
-/// From Nimbu's perspective any block that faithfully reports its authorship to the runtime
+/// From Nimbus' perspective any block that faithfully reports its authorship to the runtime
 /// is valid. The intention is that the runtime itself may then put further restrictions on
 /// the identity of the author.
 pub struct Verifier<Client, Block, CIDP> {

--- a/nimbus-consensus/src/import_queue.rs
+++ b/nimbus-consensus/src/import_queue.rs
@@ -39,7 +39,7 @@ use sp_runtime::{
 /// From Nimbu's perspective any block that faithfully reports its authorship to the runtime
 /// is valid. The intention is that the runtime itself may then put further restrictions on
 /// the identity of the author.
-struct Verifier<Client, Block, CIDP> {
+pub struct Verifier<Client, Block, CIDP> {
 	client: Arc<Client>,
 	create_inherent_data_providers: CIDP,
 	_marker: PhantomData<Block>,

--- a/nimbus-consensus/src/lib.rs
+++ b/nimbus-consensus/src/lib.rs
@@ -46,6 +46,7 @@ use std::convert::TryInto;
 use std::{marker::PhantomData, sync::Arc, time::Duration};
 use tracing::error;
 mod import_queue;
+pub use import_queue::Verifier;
 mod manual_seal;
 pub use manual_seal::NimbusManualSealConsensusDataProvider;
 

--- a/nimbus-consensus/src/lib.rs
+++ b/nimbus-consensus/src/lib.rs
@@ -24,7 +24,6 @@ use cumulus_client_consensus_common::{
 	ParachainBlockImport, ParachainCandidate, ParachainConsensus,
 };
 use cumulus_primitives_core::{relay_chain::v2::Hash as PHash, ParaId, PersistedValidationData};
-pub use import_queue::import_queue;
 use log::{debug, info, warn};
 use nimbus_primitives::{
 	AuthorFilterAPI, CompatibleDigestItem, DigestsProvider, NimbusApi, NimbusId, NIMBUS_KEY_ID,
@@ -46,7 +45,7 @@ use std::convert::TryInto;
 use std::{marker::PhantomData, sync::Arc, time::Duration};
 use tracing::error;
 mod import_queue;
-pub use import_queue::{Verifier,NimbusBlockImport};
+pub use import_queue::{import_queue, build_verifier, BuildVerifierParams, Verifier, NimbusBlockImport};
 mod manual_seal;
 pub use manual_seal::NimbusManualSealConsensusDataProvider;
 

--- a/nimbus-consensus/src/lib.rs
+++ b/nimbus-consensus/src/lib.rs
@@ -46,7 +46,7 @@ use std::convert::TryInto;
 use std::{marker::PhantomData, sync::Arc, time::Duration};
 use tracing::error;
 mod import_queue;
-pub use import_queue::Verifier;
+pub use import_queue::{Verifier,NimbusBlockImport};
 mod manual_seal;
 pub use manual_seal::NimbusManualSealConsensusDataProvider;
 

--- a/nimbus-consensus/src/lib.rs
+++ b/nimbus-consensus/src/lib.rs
@@ -320,6 +320,12 @@ where
 		relay_parent: PHash,
 		validation_data: &PersistedValidationData,
 	) -> Option<ParachainCandidate<B>> {
+        let block_id = BlockId::hash(parent.hash());
+		if !self.parachain_client.runtime_api().has_api::<dyn NimbusApi<B>>(&block_id).unwrap_or(false)
+		{
+			info!("Runtime does not have NimbusAPI, skipping block authoring");
+			return None;
+		}
 		let maybe_key = if self.skip_prediction {
 			first_available_key(&*self.keystore)
 		} else {

--- a/nimbus-consensus/src/lib.rs
+++ b/nimbus-consensus/src/lib.rs
@@ -320,28 +320,7 @@ where
 		relay_parent: PHash,
 		validation_data: &PersistedValidationData,
 	) -> Option<ParachainCandidate<B>> {
-		// Determine if runtime change
-		let runtime_upgraded = if *parent.number() > sp_runtime::traits::Zero::zero() {
-			let at = BlockId::Hash(parent.hash());
-			let parent_at = BlockId::<B>::Hash(*parent.parent_hash());
-			use sp_api::Core as _;
-			let previous_runtime_version: sp_api::RuntimeVersion = self
-				.parachain_client
-				.runtime_api()
-				.version(&parent_at)
-				.expect("Runtime api access to not error.");
-			let runtime_version: sp_api::RuntimeVersion = self
-				.parachain_client
-				.runtime_api()
-				.version(&at)
-				.expect("Runtime api access to not error.");
-
-			previous_runtime_version != runtime_version
-		} else {
-			false
-		};
-
-		let maybe_key = if self.skip_prediction || runtime_upgraded {
+		let maybe_key = if self.skip_prediction {
 			first_available_key(&*self.keystore)
 		} else {
 			first_eligible_key::<B, ParaClient>(

--- a/nimbus-consensus/src/lib.rs
+++ b/nimbus-consensus/src/lib.rs
@@ -45,7 +45,7 @@ use std::convert::TryInto;
 use std::{marker::PhantomData, sync::Arc, time::Duration};
 use tracing::error;
 mod import_queue;
-pub use import_queue::{import_queue, build_verifier, BuildVerifierParams, Verifier, NimbusBlockImport};
+pub use import_queue::{import_queue, Verifier, NimbusBlockImport};
 mod manual_seal;
 pub use manual_seal::NimbusManualSealConsensusDataProvider;
 

--- a/pallets/aura-style-filter/src/lib.rs
+++ b/pallets/aura-style-filter/src/lib.rs
@@ -74,5 +74,9 @@ pub mod pallet {
 
 			account == active_author
 		}
+		#[cfg(feature = "runtime-benchmarks")]
+        fn get_authors(_slot: &u32) -> Vec<T::AccountId> {
+			T::PotentialAuthors::get();
+        }
 	}
 }

--- a/pallets/aura-style-filter/src/lib.rs
+++ b/pallets/aura-style-filter/src/lib.rs
@@ -75,8 +75,8 @@ pub mod pallet {
 			account == active_author
 		}
 		#[cfg(feature = "runtime-benchmarks")]
-        fn get_authors(_slot: &u32) -> Vec<T::AccountId> {
+		fn get_authors(_slot: &u32) -> Vec<T::AccountId> {
 			T::PotentialAuthors::get();
-        }
+		}
 	}
 }

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -46,7 +46,7 @@ mod tests;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use crate::weights::WeightInfo;
+	pub use crate::weights::WeightInfo;
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
 


### PR DESCRIPTION
Contains all patches done to nimbus to support a composed consensus.

Does NOT contain the dependencies update from polkadot-0.9.24 to polkadot-0.9.26.
These are on https://github.com/PureStake/nimbus/pull/73